### PR TITLE
Fix bytes image input

### DIFF
--- a/img2unicode/renderer.py
+++ b/img2unicode/renderer.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from pathlib import Path
 
@@ -58,7 +59,7 @@ class Renderer:
         elif isinstance(path_or_img, np.ndarray):
             img = PIL.Image.fromarray(path_or_img)
         elif isinstance(path_or_img, bytes):
-            img = PIL.Image.frombytes(path_or_img)
+            img = PIL.Image.open(io.BytesIO(path_or_img))
         else:
             raise ValueError("Cannot interpret %s as image" % path_or_img)
 


### PR DESCRIPTION
Allows `render_terminal` to read the bytes representation of images.

[Follows the advice from the Pillow documentation](https://github.com/python-pillow/Pillow/blob/20bd9e9261919cb37b818bc0a21f991a7d8e4be4/src/PIL/Image.py#L2671-L2674):

> Note that this function decodes pixel data only, not entire images.
> If you have an entire image in a string, wrap it in a
> :py:class:`~io.BytesIO` object, and use :py:func:`~PIL.Image.open` to load
> it.

Closes #1
