### PR TITLE
chore: unlock numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='img2unicode',
         'img2unicode': ['*.npz', '*.npy'],
     },
     install_requires=[
-        'numpy>=1.19,<2',
+        'numpy>=1.19',
         'pandas',
         'scikit-image>=0.19,<1.0',
         'pillow',


### PR DESCRIPTION
I've tested the repository with the numpy version >2 (2.1.2) and it is working flawlessly.